### PR TITLE
Increase maxDeviceCount from 64 to 512

### DIFF
--- a/cl/device.go
+++ b/cl/device.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-const maxDeviceCount = 64
+const maxDeviceCount = 512
 
 type DeviceType uint
 


### PR DESCRIPTION
At first I was wondering why it won't detect over 64 GPUs, I thought I have reached Linux limit. clinfo did detect those GPUs, I did some research and it seems this library has a hard limit.
I know it's very unlikely that others will have this problem, but I did reach this limit.
Please increase it to something like 196. I'm doing a PR to increase it to 512 so most likely no one would reach 512 limit.

Thanks.